### PR TITLE
Fix template creation bug

### DIFF
--- a/xenomorphs/common/traits/kf_xeno_traits.txt
+++ b/xenomorphs/common/traits/kf_xeno_traits.txt
@@ -9,10 +9,6 @@ trait_xenomorph = {
 		always = no
 	}
 
-	species_possible_add = {
-		always = no
-	}
-
 	species_possible_remove = {
 		always = no
 	}


### PR DESCRIPTION
By removing `species_possible_add` the bug about creating templates seems resolved. I also see this tag no longer in the modding documentation: https://stellaris.paradoxwikis.com/Traits_modding